### PR TITLE
Add search service via FastAPI

### DIFF
--- a/cylleneus/service/main.py
+++ b/cylleneus/service/main.py
@@ -1,8 +1,8 @@
 import os
-from typing import List, Tuple
+from typing import List
 
 from celery.result import AsyncResult
-from dotenv import load_dotenv
+#from dotenv import load_dotenv
 from fastapi import FastAPI
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
@@ -11,46 +11,51 @@ from starlette.status import HTTP_200_OK, HTTP_202_ACCEPTED, HTTP_204_NO_CONTENT
 from . import tasks
 
 
-class Query(BaseModel):
+class CylleneusWork(BaseModel):
+    corpus: str
+    docix: int
+
+
+class CylleneusQuery(BaseModel):
     query: str
-    collection: List[Tuple[str, int]] = None
+    collection: List[CylleneusWork] = None
 
 
 # Adjust as appropriate
 root_dir = os.path.expanduser('')
-load_dotenv(os.path.join(root_dir, '.env'))
+#load_dotenv(os.path.join(root_dir, '.env'))
 
 app = FastAPI()
 
 
-@app.post("/query/")
-async def query(query: Query):
-    q = query["query"]
-    c = query["collection"]
-    result = tasks.search.delay(q, c)
-    return JSONResponse(status_code=HTTP_202_ACCEPTED, content={
+@app.post("/search/", status_code=HTTP_202_ACCEPTED)
+async def search(query: CylleneusQuery):
+    result = tasks.search.delay(query.query, query.collection)
+    return JSONResponse(content={
         'id': result.id,
     })
 
 
-@app.get("/status/{id}")
-async def status(id):
-    result = AsyncResult(id=id, backend='redis://localhost')
+@app.get("/status/")
+async def status(id: str):
+    result = tasks.search.AsyncResult(id)
 
     return {"status": result.status}
 
 
-@app.get("/results/{id}")
-async def results(id):
-    result = AsyncResult(id=id, backend='redis://localhost')
+@app.get("/results/", status_code=HTTP_200_OK)
+async def results(id: str):
+    result = tasks.search.AsyncResult(id)
 
     if result.ready():
-        if result.result:
-            response = JSONResponse(status_code=HTTP_200_OK, content={
-                "result": result.result
+        response = JSONResponse(content={
+                "result": result.get()
             })
-        else:
-            response = JSONResponse(status_code=HTTP_204_NO_CONTENT)
     else:
         response = JSONResponse(status_code=HTTP_400_BAD_REQUEST)
     return response
+
+@app.get("/index/", status_code=HTTP_200_OK)
+async def index(corpus: str):
+    result = tasks.index(corpus)    
+    return JSONResponse(content={ corpus: result })

--- a/cylleneus/service/main.py
+++ b/cylleneus/service/main.py
@@ -1,0 +1,56 @@
+import os
+from typing import List, Tuple
+
+from celery.result import AsyncResult
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from pydantic import BaseModel
+from starlette.responses import JSONResponse
+from starlette.status import HTTP_200_OK, HTTP_202_ACCEPTED, HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
+
+from . import tasks
+
+
+class Query(BaseModel):
+    query: str
+    collection: List[Tuple[str, int]] = None
+
+
+# Adjust as appropriate
+root_dir = os.path.expanduser('')
+load_dotenv(os.path.join(root_dir, '.env'))
+
+app = FastAPI()
+
+
+@app.post("/query/")
+async def query(query: Query):
+    q = query["query"]
+    c = query["collection"]
+    result = tasks.search.delay(q, c)
+    return JSONResponse(status_code=HTTP_202_ACCEPTED, content={
+        'id': result.id,
+    })
+
+
+@app.get("/status/{id}")
+async def status(id):
+    result = AsyncResult(id=id, backend='redis://localhost')
+
+    return {"status": result.status}
+
+
+@app.get("/results/{id}")
+async def results(id):
+    result = AsyncResult(id=id, backend='redis://localhost')
+
+    if result.ready():
+        if result.result:
+            response = JSONResponse(status_code=HTTP_200_OK, content={
+                "result": result.result
+            })
+        else:
+            response = JSONResponse(status_code=HTTP_204_NO_CONTENT)
+    else:
+        response = JSONResponse(status_code=HTTP_400_BAD_REQUEST)
+    return response

--- a/cylleneus/service/tasks.py
+++ b/cylleneus/service/tasks.py
@@ -9,17 +9,20 @@ Cylleneus = Celery(
     backend='redis://localhost',
     broker='pyamqp://guest@localhost//',
 )
-Cylleneus.conf.broker_heartbeat = 0
-Cylleneus.conf.result_persistent = True
-Cylleneus.conf.worker_prefetch_multiplier = 0
 
 
-@Cylleneus.task(acks_late=True)
+@Cylleneus.task
 def search(q, collection=None):
     if collection:
-        c = Collection([Corpus(corpus).work_by_docix(docix) for corpus, docix in collection])
+        c = Collection([Corpus(work.corpus).work_by_docix(work.docix) for work in collection])
     else:
-        c = Collection(Corpus("lasla").works)
+        c = Collection(Corpus("perseus").works)
     searcher = Searcher(c)
     s = searcher.search(q)
     return s.to_json()
+
+@Cylleneus.task
+def index(corpus):
+    return [ { "docix": work.docix,
+          "author": work.author,
+          "title": work.title } for work in Corpus(corpus).works]

--- a/cylleneus/service/tasks.py
+++ b/cylleneus/service/tasks.py
@@ -1,0 +1,25 @@
+from celery import Celery
+
+from corpus import Corpus
+from search import Searcher, Collection
+
+# Create the app and set the broker location
+Cylleneus = Celery(
+    'cylleneus',
+    backend='redis://localhost',
+    broker='pyamqp://guest@localhost//',
+)
+Cylleneus.conf.broker_heartbeat = 0
+Cylleneus.conf.result_persistent = True
+Cylleneus.conf.worker_prefetch_multiplier = 0
+
+
+@Cylleneus.task(acks_late=True)
+def search(q, collection=None):
+    if collection:
+        c = Collection([Corpus(corpus).work_by_docix(docix) for corpus, docix in collection])
+    else:
+        c = Collection(Corpus("lasla").works)
+    searcher = Searcher(c)
+    s = searcher.search(q)
+    return s.to_json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 Click>=6.0
+celery[redis]>=4.3.0
 certifi==2019.3.9
 chardet==3.0.4
 click-spinner>=0.1.8
 cursor==1.3.4
+fastapi>=0.42.0
 fastnumbers>=2.2.1
 flask>=1.1.1
 future==0.17.1
@@ -11,6 +13,7 @@ html3>=1.17
 idna==2.8
 isodate==0.6.0
 latinwordnet>=0.2.4
+librabbitmq>=2.0.0
 lxml==4.3.2
 MyCapytain==2.0.10
 multiwordnet>=0.0.4
@@ -33,4 +36,5 @@ singledispatch==3.4.0.3
 six==1.12.0
 tqdm==4.31.1
 urllib3<1.25,>=1.21.1
+uvicorn>=0.10.8
 Whoosh==2.7.4

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,11 @@ version = find_version('cylleneus', '__init__.py')
 requirements = [
     'Click>=6.0',
     'certifi>=2019.3.9',
+    'celery[redis]>=4.3.0',
     'chardet>=3.0.4',
     'click-spinner>=0.1.8',
     'cursor>=1.3.4',
+    'fastapi>=0.42.0',
     'fastnumbers>=2.2.1',
     'flask>=1.1.1',
     'future>=0.17.1',
@@ -56,6 +58,7 @@ requirements = [
     'idna>=2.8',
     'isodate>=0.6.0',
     'latinwordnet>=0.2.4',
+    'librabbitmq>=2.0.0',
     'lxml>=4.3.2',
     'MyCapytain>=2.0.10',
     'multiwordnet>=0.0.4',
@@ -77,6 +80,7 @@ requirements = [
     'six>=1.12.0',
     'tqdm>=4.31.1',
     'urllib3<1.25,>=1.21.1',
+    'uvicorn>=0.10.8',
     'Whoosh>=2.7.4',
 ]
 


### PR DESCRIPTION
This PR adds a search service to Cylleneus, using FastAPI running on Uvicorn. The service also uses Celery/RabbitMQ (and Redis for caching) in the back-end, to enable asynchronous handling of long-running queries. Once running the API will accept POST requests with a payload consisting of the query and (optionally) a list of corpus-name and document ID pairs, e.g.,
{
    "query": "quoque",
    "collection": [ ("perseus", 2) ]
}
Document ID numbers can be obtained by passing a corpus name via GET request to /index.

If well formed the request will return a unique identifier for the search, which can be used to poll the service for the status of the search. This is done by passing the unique ID via GET request to /status. Finally, once the status of the search is "SUCCEEDED", its results can be obtained in JSON format by again passing the ID string via GET requests to /results.